### PR TITLE
feat(blog): add wiki 1.0 launch blogpost

### DIFF
--- a/content/blog/projects/wiki-1-0.mdx
+++ b/content/blog/projects/wiki-1-0.mdx
@@ -10,7 +10,7 @@ category: 'Projects'
 
 After over a year of development, refinement, and collaboration, **atl.wiki 1.0** is officially here. This marks a huge milestone for the project — with better tools, clearer policies, and a stronger foundation, we're ready to serve the Linux and FOSS community better than ever before.
 
-For those not familar with the wiki, in May of 2024 we launched https://atl.wiki with the goal of providing reliable and informative resources to users of all ability levels of Linux and adjacent FOSS software. We have so far amasssed 3000 edits over 200 pages from 130 users, and we welcome you to join us in growing the wiki!
+For those not familiar with the wiki, in May of 2024 we launched https://atl.wiki with the goal of providing reliable and informative resources to users of all ability levels of Linux and adjacent FOSS software. We have so far amassed 3000 edits over 200 pages from 130 users, and we welcome you to join us in growing the wiki!
 
 ## ✅ What's changed?
 

--- a/content/blog/projects/wiki-1-0.mdx
+++ b/content/blog/projects/wiki-1-0.mdx
@@ -1,0 +1,56 @@
+---
+title: 'atl.wiki 1.0 Release'
+description: 'All Things Linux’s wiki is now officially releasing, see all the changes we have made along the way so far!'
+author: 'Atmois'
+date: '2025-01-08'
+category: 'Projects'
+---
+
+# 🎉 Announcing atl.wiki 1.0 — A New Era for the Wiki
+
+After over a year of development, refinement, and collaboration, **atl.wiki 1.0** is officially here. This marks a huge milestone for the project — with better tools, clearer policies, and a stronger foundation, we're ready to serve the Linux and FOSS community better than ever before.
+
+For those not familar with the wiki, in May of 2024 we launched https://atl.wiki with the goal of providing reliable and informative resources to users of all ability levels of Linux and adjacent FOSS software. We have so far amasssed 3000 edits over 200 pages from 130 users, and we welcome you to join us in growing the wiki!
+
+## ✅ What's changed?
+
+- **Full infrastructure rebuild:**
+  We reinstalled MediaWiki from scratch for a clean and maintainable setup and we moved the wiki database to its own secure server for improved resilience and security. Scott also assisted in migrating from Apache to NGINX for faster page loads and easier configuration management.
+
+- **Short URLs implemented:**
+  We now use URLs like `atl.wiki/Page_Title` instead of `atl.wiki/w/index.php?title=Page_Title`, for a cleaner experience. This went hand in hand with improved visibility and indexing across search engines to help users discover content.
+
+- **New homepage design:**
+  Rebuilt from the ground up to be more useful, readable, and visually appealing to give a user a better experience when first finding and using the wiki.
+
+- **Dedicated staging wiki:**
+  Allows safe testing of config changes without impacting the live wiki. We also adopted a long-term support versions only for improved stability and security for the wiki.
+
+- **Launched Guides section:**
+  A curated space for step-by-step tutorials and helpful walkthroughs in any topic you can think of. Its a crowd sourced guide space for authors to nerd out about their interests and share their knowledge and experience.
+
+- **Expanded and rewritten policies:**
+  We established and wrote our extensive guidelines and policies to guide authors on how to best write content for the wiki. We also created and refined a privacy policy and disclaimer to be as transparent to users as possible about how the wiki funcitons.
+
+
+- **Revamped page moderation:**
+  It helped us streamline editing while keeping quality control where it matters most. We also deployed Cloudflare Turnstile which blocks bots during signup without annoying captchas for the users.
+
+- **User experience features added:**
+  Logged-in users get access to favorites, TOTP 2FA, and more as well as SSO which simplifies internal account management and improves staff security.
+
+- **Established core community values:**
+  We're guided by five key principles:
+  - **Accuracy** - factual, well-sourced content
+  - **Impartiality** - free from bias
+  - **Consistency** - clean, unified standards
+  - **Courtesy** - respectful collaboration
+  - **Accessibility** - open and usable by all
+
+## 🌱 What's Next
+
+To everyone who contributed or supported the project — thank you. Your time and effort helped shape the wiki into what it is today. We hope you've found atl.wiki useful, and we're always looking forward to welcoming new editors and readers into the community.
+
+Here's to the future of atl.wiki, we hope to see you there with us!
+
+- **atmois** (Head of Wiki Operations)

--- a/content/blog/projects/wiki-1-0.mdx
+++ b/content/blog/projects/wiki-1-0.mdx
@@ -27,7 +27,7 @@ For those not familar with the wiki, in May of 2024 we launched https://atl.wiki
   Allows safe testing of config changes without impacting the live wiki. We also adopted a long-term support versions only for improved stability and security for the wiki.
 
 - **Launched Guides section:**
-  A curated space for step-by-step tutorials and helpful walkthroughs in any topic you can think of. Its a crowd sourced guide space for authors to nerd out about their interests and share their knowledge and experience.
+  A curated space for step-by-step tutorials and helpful walkthroughs in any topic you can think of. It's a crowd sourced guide space for authors to nerd out about their interests and share their knowledge and experience.
 
 - **Expanded and rewritten policies:**
   We established and wrote our extensive guidelines and policies to guide authors on how to best write content for the wiki. We also created and refined a privacy policy and disclaimer to be as transparent to users as possible about how the wiki funcitons.

--- a/content/blog/projects/wiki-1-0.mdx
+++ b/content/blog/projects/wiki-1-0.mdx
@@ -10,7 +10,7 @@ category: 'Projects'
 
 After over a year of development, refinement, and collaboration, **atl.wiki 1.0** is officially here. This marks a huge milestone for the project — with better tools, clearer policies, and a stronger foundation, we're ready to serve the Linux and FOSS community better than ever before.
 
-For those not familiar with the wiki, in May of 2024 we launched https://atl.wiki with the goal of providing reliable and informative resources to users of all ability levels of Linux and adjacent FOSS software. We have so far amassed 3000 edits over 200 pages from 130 users, and we welcome you to join us in growing the wiki!
+For those not familiar with the wiki, in May of 2024 we launched [atl.wiki](https://atl.wiki) with the goal of providing reliable and informative resources to users of all ability levels of Linux and adjacent FOSS software. We have so far amassed 3000 edits over 200 pages from 130 users, and we welcome you to join us in growing the wiki!
 
 ## ✅ What's changed?
 


### PR DESCRIPTION
create wiki 1.0 annoucment post

## Summary by Sourcery

Documentation:
- Add blog post announcing atl.wiki 1.0 launch with details on infrastructure overhaul, URL improvements, design updates, new features, and community policies