### PR TITLE
Create September 2025 Roundup blog post

### DIFF
--- a/content/blog/news/09-2025-roundup.mdx
+++ b/content/blog/news/09-2025-roundup.mdx
@@ -1,21 +1,21 @@
 ---
-title: September 2025 Roundup'
+title: 'September 2025 Roundup'
 description: 'Quietly powering through!'
 author: 'All Things Linux'
 date: '2025-09-30'
 category: 'News'
 ---
 
-# Membership status 
+# Membership status
 
-As per usual, our community continued to expand - we managed to  reach the loft heights of 15,000 members! Hard to imagine just how far we’ve come. 
+As per usual, our community continued to expand — we managed to reach the lofty heights of 15,000 members! Hard to imagine just how far we’ve come. 
 
-This month, we managed to average around 16,125 messages per day, and 117 hours of VC!
+This month, we averaged around 16,125 messages per day and 117 hours of VC. We also flew past **8 million total messages** — thank you to everyone who helps keep the place buzzing! 🔥
 
 # Anything happening over here?
 
 September proved to be a relatively quiet month by our usual standards. All in all, it was a month of fewer headline moments and continued graft and behind-the-scenes progress to keep pushing towards our community goals.
 
-That’s all from us for now - short and sweet. 
+That’s all from us for now — short and sweet. 
 
 Much love to all of you, see you next month!

--- a/content/blog/news/09-2025-roundup.mdx
+++ b/content/blog/news/09-2025-roundup.mdx
@@ -1,0 +1,21 @@
+---
+title: September 2025 Roundup'
+description: 'Quietly powering through!'
+author: 'All Things Linux'
+date: '2025-09-30'
+category: 'News'
+---
+
+# Membership status 
+
+As per usual, our community continued to expand - we managed to  reach the loft heights of 15,000 members! Hard to imagine just how far we’ve come. 
+
+This month, we managed to average around 16,125 messages per day, and 117 hours of VC!
+
+# Anything happening over here?
+
+September proved to be a relatively quiet month by our usual standards. All in all, it was a month of fewer headline moments and continued graft and behind-the-scenes progress to keep pushing towards our community goals.
+
+That’s all from us for now - short and sweet. 
+
+Much love to all of you, see you next month!

--- a/content/blog/news/10-2025-roundup.mdx
+++ b/content/blog/news/10-2025-roundup.mdx
@@ -1,34 +1,34 @@
 ---
-title: October 2025 Roundup'
-description: “Opening our work to the public”
-author: 'All Things Linux'
+title: 'October 2025 Roundup'
+description: 'Opening our work to the public'
+author: 'Farcotton'
 date: '2025-10-31'
 category: 'News'
 ---
 
 # How big has the family gotten this time?
 
-Welcome to October everyone - we know you like your statistics, so here you go:
+Welcome to October, everyone — we know you like your statistics, so here you go:
 
-- Membership rose to 16.074 members!
-- Averaging 15,920 messages and 100 hours of vc per day!
+- Membership rose to 16,074 members!
+- Averaging 15,920 messages and 100 hours of VC per day!
 
 # Come take a look
 
 We’ve opened up our work to our members in true open-source fashion. 
 
-You can now take a look at our live roadmap and objectives via Fibery, which has become our new organisational home. Our increased visiblity comes after some quieter few months and is a prt of our collective staff effort to improve transparency around where time, effort and your generous donations are going. As this continues to evolve, we hope to cointinue to build trust and clarity with you moving fowards. 
+You can now take a look at our live roadmap and objectives via Fibery, which has become our new organizational home. Our increased visibility comes after a quieter few months and is part of our collective staff effort to improve transparency around where time, effort, and your generous donations are going. As this continues to evolve, we hope to continue to build trust and clarity with you moving forward. 
 
 You can view the public roadmap [here](https://allthingslinux.fibery.io/@public)
 
 # Banners, banners, banners
 
-What’s that you say? You wonder where all ou old server banners are kept?
+What’s that you say? You wonder where all our old server banners are kept?
 
-Well, you’re in luck! You browse through our creative banner choices, both old and new [here](https://github.com/allthingslinux/assets)  
+Well, you’re in luck! You can browse through our creative banner choices, both old and new, [here](https://github.com/allthingslinux/assets).
 
 Enjoy! 
 
-# And that’s all folks 
+# And that’s all, folks 
 
-Thus brings to an end an open, more transparent month at ATL - catch you all in the next one!
+This brings an end to an open, more transparent month at ATL — catch you all in the next one!

--- a/content/blog/news/10-2025-roundup.mdx
+++ b/content/blog/news/10-2025-roundup.mdx
@@ -1,0 +1,34 @@
+---
+title: October 2025 Roundup'
+description: “Opening our work to the public”
+author: 'All Things Linux'
+date: '2025-10-31'
+category: 'News'
+---
+
+# How big has the family gotten this time?
+
+Welcome to October everyone - we know you like your statistics, so here you go:
+
+- Membership rose to 16.074 members!
+- Averaging 15,920 messages and 100 hours of vc per day!
+
+# Come take a look
+
+We’ve opened up our work to our members in true open-source fashion. 
+
+You can now take a look at our live roadmap and objectives via Fibery, which has become our new organisational home. Our increased visiblity comes after some quieter few months and is a prt of our collective staff effort to improve transparency around where time, effort and your generous donations are going. As this continues to evolve, we hope to cointinue to build trust and clarity with you moving fowards. 
+
+You can view the public roadmap [here](https://allthingslinux.fibery.io/@public)
+
+# Banners, banners, banners
+
+What’s that you say? You wonder where all ou old server banners are kept?
+
+Well, you’re in luck! You browse through our creative banner choices, both old and new [here](https://github.com/allthingslinux/assets)  
+
+Enjoy! 
+
+# And that’s all folks 
+
+Thus brings to an end an open, more transparent month at ATL - catch you all in the next one!

--- a/content/blog/news/11-2025-roundup.mdx
+++ b/content/blog/news/11-2025-roundup.mdx
@@ -1,49 +1,72 @@
 ---
-title: November 2025 Roundup'
-description: “Happy 2 year anniversary ATL!”
+title: 'November 2025 Roundup'
+description: 'Happy 2 year anniversary ATL!'
 author: 'All Things Linux'
 date: '2025-11-30'
 category: 'News'
 ---
 
-# How’s the memberhsip looking?
+# 2 Years of ATL 
+
+This November, on the 9th, we hit 2 years as a community. At almost 9 million messages, this was truly something extraordinary. And for certain, we could not have done it without each and every single one of you. 
+
+## How’s the membership looking?
 
 Growing, as usual. All thanks to our amazing community. 
 
 We’ve got some quick stats for you:
 
 - 17,538 members 
-- Averaging 12,664 messages per day 
+- 9,000,000+ messages (nearly 12,000 messages per day for 730 days!)
 - 102 hours of VC per day on average
 
 Still climbing and kicking strong! 
 
-# 2 Years of ATL 
-
-This November, on the 9th, we hit 2 years as a community. At almost 9 million messages, this was truly something extraordinary. And for certain, we could not have done it without each and every single one of you. 
-
 # Management changes
 
-We’re so happy to announce `@estralia` as our very first Director of Moderation - this role is responsible for overseeing the moderation of the server, as well as establishing the team culture, developing new policies and scouting fresh recruits!
+- In Aug 2025, we promoted `@farcotton` to now be acting as our newest Admin.
+- In Oct 2025, we appointed a new role of Director of Moderation to `@estralia`.
+- We’ve also recently formed an **Events Team** to start planning out routine fun events and activities across the server next year.
 
-We’ve also introduced the Events Team - who will be putting together some awesome new events and experiences - coming soon!
+# Promoting transparency
+
+- In Jan 2026, we will be releasing a public ledger of all financials.
+- You can now view a public roadmap of all ongoing ATL projects here: [Public Roadmap](https://allthingslinux.fibery.io/@public/Public_Roadmap)
+- You can now view all ATL assets, like all the cool banners we've had over the past 2 years, here: [ATL Assets](https://github.com/allthingslinux/assets)
 
 # Infrastructure improvements 
 
-- We’ve added some new bits and bobs to https://atl.tools and spruced up the UI 
-- Overhauled internal security via VaultWarden, Cloudfare Access, Okta and Tailscale 
-- Distributed various services fro, a central machine to a distributed architecture 
-- Converted our Code of Conduct to be more “machine readable” to open up avenues for future integrations of it, you can check it out [here](https://github.com/allthingslinux/code-of-conduct)
+- We’ve added some new tools to [atl.tools](https://atl.tools) and improved the website UI slightly.
+- We’ve implemented a standard security/reporting policy across our services: [Security Policy](https://allthingslinux.org/security)
+- Enhanced internal security via Vaultwarden, Cloudflare Access, Okta, and Tailscale.
+- Distributed various services from a central machine to a distributed architecture.
+- Converted our code of conduct to be "machine readable" to allow for future integrations of it: [Code of Conduct](https://github.com/allthingslinux/code-of-conduct)
+- Soon we will be migrating the atl.tools mail server to a new datacenter provider, completely repolished and documented internally.
+- Soon we will be moving to a monorepo/GitOps/IaC-style architecture for all existing and future projects.
 
-# Steam group??
+# atl.wiki
 
-Yes, that’s right! 
+In Aug 2025, our homegrown wiki, [atl.wiki](https://atl.wiki), had its first 1.0 release! As of today, the wiki has 301 pages, 4,205 edits, and 245 users. We appreciate everyone who has helped contribute and encourage you to get involved. A wiki takes a team, and we believe that we can make this wiki a one-of-a-kind resource for the Linux ecosystem.
 
-We now have an official ATL Steam group, and we’d love for you to join - it’s invite only and you can find the link [here](https://steamcommunity.com/groups/allthingslinux)
+# atl.chat
 
-Stay tuned for some potential events in the future *wink wink* 
+Over the past few months, we've slowly been rebuilding our IRC and XMPP servers to be of the highest quality and compliance. Currently the release of these is blocked by a new project codenamed **Portal**, which we will share more info about in the coming months. You can view the new implementations at [irc.atl.chat](https://github.com/allthingslinux/irc.atl.chat) and [xmpp.atl.chat](https://github.com/allthingslinux/xmpp.atl.chat).
+
+# Tux
+
+Not only has ATL been 2 years in the making, but Tux, our custom Discord bot, has also been in formation across those 2 years. Tux was created on Nov 11th, 2023. As of today, Tux has about 60K lines of code, 3.2K commits, and ~40 contributors. We will soon be releasing [v0.1.0](https://github.com/allthingslinux/tux/tree/v0.1.0) and a polished roadmap. Once that is released, we are calling anyone who is familiar with Python to help contribute and make Tux the greatest open-source Discord bot.
+
+# Mod apps reopened
+
+Lastly, our mod team is currently looking to grow, so we encourage you to apply if you have any desire to help support and keep our community safe. You can find said application and others here: [atl.sh/apply](https://atl.sh/apply)
+
+# Steam group
+
+We now have an official ATL Steam group, and we’d love for you to join - it’s invite only and you can find the link [here](https://steamcommunity.com/groups/allthingslinux). Stay tuned for some potential events in the future *wink wink*!
 
 # Wowie 
+
+Again, from the entire team and me, thank you for supporting All Things Linux. And to all of our Donors, a special thank you for believing in our vision and allowing us to continue building. We couldn't do this without you!
 
 Busy month, wasn’t it?
 

--- a/content/blog/news/11-2025-roundup.mdx
+++ b/content/blog/news/11-2025-roundup.mdx
@@ -1,0 +1,51 @@
+---
+title: November 2025 Roundup'
+description: “Happy 2 year anniversary ATL!”
+author: 'All Things Linux'
+date: '2025-11-30'
+category: 'News'
+---
+
+# How’s the memberhsip looking?
+
+Growing, as usual. All thanks to our amazing community. 
+
+We’ve got some quick stats for you:
+
+- 17,538 members 
+- Averaging 12,664 messages per day 
+- 102 hours of VC per day on average
+
+Still climbing and kicking strong! 
+
+# 2 Years of ATL 
+
+This November, on the 9th, we hit 2 years as a community. At almost 9 million messages, this was truly something extraordinary. And for certain, we could not have done it without each and every single one of you. 
+
+# Management changes
+
+We’re so happy to announce `@estralia` as our very first Director of Moderation - this role is responsible for overseeing the moderation of the server, as well as establishing the team culture, developing new policies and scouting fresh recruits!
+
+We’ve also introduced the Events Team - who will be putting together some awesome new events and experiences - coming soon!
+
+# Infrastructure improvements 
+
+- We’ve added some new bits and bobs to https://atl.tools and spruced up the UI 
+- Overhauled internal security via VaultWarden, Cloudfare Access, Okta and Tailscale 
+- Distributed various services fro, a central machine to a distributed architecture 
+- Converted our Code of Conduct to be more “machine readable” to open up avenues for future integrations of it, you can check it out [here](https://github.com/allthingslinux/code-of-conduct)
+
+# Steam group??
+
+Yes, that’s right! 
+
+We now have an official ATL Steam group, and we’d love for you to join - it’s invite only and you can find the link [here](https://steamcommunity.com/groups/allthingslinux)
+
+Stay tuned for some potential events in the future *wink wink* 
+
+# Wowie 
+
+Busy month, wasn’t it?
+
+Let’s take a breather, and we’ll catch you in the next one!
+

--- a/content/blog/news/12-2025-roundup.mdx
+++ b/content/blog/news/12-2025-roundup.mdx
@@ -1,0 +1,55 @@
+---
+title: December 2025 Roundup'
+description: “End of a Year”
+author: 'All Things Linux'
+date: '2025-12-31'
+category: 'News'
+---
+
+# First and foremost ...
+
+Let’s count the numbers shall we? 
+
+- 18,360 members to round out the year
+- 13,389 messages on average per day 
+- Averaging 72 hours of VC per day 
+
+# We need your ideas
+
+Last month, we introduced the Events Team to rustle up some exciting events for the server, starting from January 2026. 
+
+We already have a few ideas in mind, but we’d love to hear your thoughts too - you can fill out a form with your suggestions [here](https://cryptpad.fr/form/#/2/form/view/Nqh6n+oiEU2QIVdzgJbl-Mx6eWG2BNvlTGkw+tjV600/)
+
+# Return of the Nix channel?
+
+Nixers amongst you - rejoice!
+
+The `#nix` channel, at the request of our member has been brought back - have fun endlessly discussing flakes guys!
+
+# Advent of Code Winner
+
+Congratulations to our winner `@thebyteslayer` for coming out on top after 12 gruelling challenges!
+
+Also a big round of applause to our runner ups, `@waaberi` and `@susanthenerd` for taking 2nd and 3rd places respectively.
+
+# Code of Conduct Rewrite 
+With `’@aimai` at the helm and some other helping hands, we’ve completed a major rewrite of our Code of Conduct to better reflect our mission. The update focuses on clearer rule definitions, improved guidance around enforcement and modernisation to support our growing community.
+The revised Code of Conduct will come into effect on 1st January 2026, which should give everyone time to review the changes. Community feedback is still welcome as we continue to refine the document.
+
+Check out the updated Code of Conduct [here](https://allthingslinux.org/code-of-conduct)
+# Team Expansion
+
+Welcoming to the team we have:
+
+Systems Administrators: `@wilbycat48` `@sg37` `@bippington` `@ikci` `@joetroll` `@polymo1` `@susanthenerd`
+Devs: `@im.ela` `@fr3sh` `@pepper314`
+Moderators (new and returning): `@ayru.dev` `@yingvay` `@beacrox` `@nickname5491` `@toyotarav41996`
+
+ Jr. Moderators: `@inzane84` `@parametheus` 
+# And that’s a wrap 
+
+Well, that’s it - this brings us to the end ofr a booming 2025.
+Thank you to each and everyone single one you, for making this place what it is. 
+
+All that’s left to say from us is: Merry Christmas ATL, and a Happy New Year!
+ 

--- a/content/blog/news/12-2025-roundup.mdx
+++ b/content/blog/news/12-2025-roundup.mdx
@@ -1,6 +1,6 @@
 ---
-title: December 2025 Roundup'
-description: “End of a Year”
+title: 'December 2025 Roundup'
+description: 'End of a Year'
 author: 'All Things Linux'
 date: '2025-12-31'
 category: 'News'
@@ -8,7 +8,7 @@ category: 'News'
 
 # First and foremost ...
 
-Let’s count the numbers shall we? 
+Let’s count the numbers, shall we? 
 
 - 18,360 members to round out the year
 - 13,389 messages on average per day 
@@ -18,38 +18,42 @@ Let’s count the numbers shall we?
 
 Last month, we introduced the Events Team to rustle up some exciting events for the server, starting from January 2026. 
 
-We already have a few ideas in mind, but we’d love to hear your thoughts too - you can fill out a form with your suggestions [here](https://cryptpad.fr/form/#/2/form/view/Nqh6n+oiEU2QIVdzgJbl-Mx6eWG2BNvlTGkw+tjV600/)
+We already have a few ideas in mind, but we’d love to hear your thoughts too — you can fill out a form with your suggestions [here](https://cryptpad.fr/form/#/2/form/view/Nqh6n+oiEU2QIVdzgJbl-Mx6eWG2BNvlTGkw+tjV600/)
 
 # Return of the Nix channel?
 
-Nixers amongst you - rejoice!
+Nixers amongst you — rejoice!
 
-The `#nix` channel, at the request of our member has been brought back - have fun endlessly discussing flakes guys!
+The `#nix` channel, at the request of our members, has been brought back — have fun endlessly discussing flakes, guys!
 
 # Advent of Code Winner
 
-Congratulations to our winner `@thebyteslayer` for coming out on top after 12 gruelling challenges!
+Congratulations to our winner, `@thebyteslayer`, for coming out on top after 12 grueling challenges!
 
-Also a big round of applause to our runner ups, `@waaberi` and `@susanthenerd` for taking 2nd and 3rd places respectively.
+Also, a big round of applause to our runners-up, `@waaberi` and `@susanthenerd`, for taking 2nd and 3rd place respectively.
 
 # Code of Conduct Rewrite 
-With `’@aimai` at the helm and some other helping hands, we’ve completed a major rewrite of our Code of Conduct to better reflect our mission. The update focuses on clearer rule definitions, improved guidance around enforcement and modernisation to support our growing community.
-The revised Code of Conduct will come into effect on 1st January 2026, which should give everyone time to review the changes. Community feedback is still welcome as we continue to refine the document.
+
+With `@aimai` at the helm and some other helping hands, we’ve completed a major rewrite of our Code of Conduct to better reflect our mission. The update focuses on clearer rule definitions, improved guidance around enforcement, and modernization to support our growing community.
+
+The revised Code of Conduct will come into effect on January 1, 2026, which should give everyone time to review the changes. Community feedback is still welcome as we continue to refine the document.
 
 Check out the updated Code of Conduct [here](https://allthingslinux.org/code-of-conduct)
+
 # Team Expansion
 
-Welcoming to the team we have:
+Welcoming to the team, we have:
 
 Systems Administrators: `@wilbycat48` `@sg37` `@bippington` `@ikci` `@joetroll` `@polymo1` `@susanthenerd`
 Devs: `@im.ela` `@fr3sh` `@pepper314`
 Moderators (new and returning): `@ayru.dev` `@yingvay` `@beacrox` `@nickname5491` `@toyotarav41996`
 
- Jr. Moderators: `@inzane84` `@parametheus` 
+Jr. Moderators: `@inzane84` `@parametheus` 
+
 # And that’s a wrap 
 
-Well, that’s it - this brings us to the end ofr a booming 2025.
-Thank you to each and everyone single one you, for making this place what it is. 
+Well, that’s it — this brings us to the end of a booming 2025.
+Thank you to each and every single one of you for making this place what it is. 
 
 All that’s left to say from us is: Merry Christmas ATL, and a Happy New Year!
  


### PR DESCRIPTION
Added a new roundup blog post for September 2025.

## Summary by Sourcery

Documentation:
- Add a September 2025 roundup blog article covering community membership metrics and monthly highlights.