### PR TITLE
feat(app): add a contribute/donate page

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -54,7 +54,7 @@ export default function About() {
                 <span className="text-green-500 mr-2">~/</span>Our Community
               </h3>
               <p className="text-sm sm:text-base md:text-lg leading-relaxed text-balance">
-                We are a diverse community of over 14,000 Linux enthusiasts,
+                We are a diverse community of over 20,000 Linux enthusiasts,
                 passionate about advancing technology and sharing knowledge. Our
                 organization is dedicated to promoting the spirit and growth of
                 Linux through collaboration and innovation.

--- a/app/apply/[role]/page.tsx
+++ b/app/apply/[role]/page.tsx
@@ -182,7 +182,7 @@ export default function RoleApplicationPage() {
         <div className="w-full max-w-[800px]">
           {/* Back button */}
           <div className="mb-6">
-            <Link href="/get-involved" passHref>
+            <Link href="/apply" passHref>
               <Button
                 variant="ghost"
                 size="sm"

--- a/app/apply/page.tsx
+++ b/app/apply/page.tsx
@@ -37,7 +37,7 @@ const Hero = memo(({ roleCount }: { roleCount: number }) => (
         </div>
 
         <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold text-center mb-6">
-          Get Involved
+          Apply
         </h1>
 
         <p className="text-base sm:text-lg md:text-xl text-center text-muted-foreground mb-8">
@@ -100,6 +100,7 @@ const SearchInput = memo(
 
           {value && (
             <button
+              type="button"
               onClick={handleClear}
               className="absolute right-4 top-1/2 -translate-y-1/2 text-muted-foreground/50 hover:text-muted-foreground/80 p-1.5 z-10"
               aria-label="Clear search"
@@ -111,6 +112,7 @@ const SearchInput = memo(
                 fill="none"
                 xmlns="http://www.w3.org/2000/svg"
               >
+                <title>Clear search</title>
                 <path
                   d="M18 6L6 18M6 6L18 18"
                   stroke="currentColor"
@@ -195,7 +197,7 @@ const DepartmentSection = memo(
       <div className="flex items-center justify-between mb-4 sm:mb-6 md:mb-8 flex-wrap sm:flex-nowrap gap-2">
         <div className="flex items-center gap-2 sm:gap-4 w-full">
           <h2 className="text-xl sm:text-2xl font-semibold">{department}</h2>
-          <div className="h-[1px] bg-border flex-grow hidden sm:block"></div>
+          <div className="h-px bg-border grow hidden sm:block"></div>
         </div>
         <Badge
           variant="outline"

--- a/app/contribute/page.tsx
+++ b/app/contribute/page.tsx
@@ -73,10 +73,10 @@ export default function ContributePage() {
                   has the lowest fees but every.org provides more currency
                   options.
                 </i>{' '}
-                <b>
+                <strong>
                   For larger donations or more details on how the fees work you
                   can click the "Learn More" button above.
-                </b>
+                </strong>  
               </span>
             </CardDescription>
           </CardHeader>
@@ -190,7 +190,7 @@ export default function ContributePage() {
                 </CardTitle>
               </div>
               <CardDescription className="text-lg">
-                Share your knowledge by contributing editing or writing articles
+                Share your knowledge by contributing, editing or writing articles
                 and guides.
               </CardDescription>
             </CardHeader>

--- a/app/contribute/page.tsx
+++ b/app/contribute/page.tsx
@@ -81,15 +81,16 @@ export default function ContributePage() {
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <div className="grid grid-cols-3 gap-3">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
               <Button asChild className="w-full">
                 <Link
                   href="https://opencollective.com/allthingslinux"
                   target="_blank"
                   rel="noopener noreferrer"
+                  className="flex items-center justify-center gap-2"
                 >
                   <SiOpencollective size={16} />
-                  Open Collective
+                  <span>Open Collective</span>
                 </Link>
               </Button>
               <Button asChild className="w-full" variant="outline">
@@ -97,9 +98,10 @@ export default function ContributePage() {
                   href="https://paypal.com/donate/?hosted_button_id=9R5Y3RDAMF6D8"
                   target="_blank"
                   rel="noopener noreferrer"
+                  className="flex items-center justify-center gap-2"
                 >
                   <SiPaypal size={16} />
-                  PayPal
+                  <span>PayPal</span>
                 </Link>
               </Button>
               <Button asChild className="w-full" variant="outline">
@@ -107,9 +109,10 @@ export default function ContributePage() {
                   href="https://donate.stripe.com/bJe8wQf5O2ZccHW06u1wY07"
                   target="_blank"
                   rel="noopener noreferrer"
+                  className="flex items-center justify-center gap-2"
                 >
                   <SiStripe size={16} />
-                  Stripe (Monthly)
+                  <span>Stripe (Monthly)</span>
                 </Link>
               </Button>
               <Button asChild className="w-full" variant="outline">
@@ -117,9 +120,10 @@ export default function ContributePage() {
                   href="https://every.org/allthingslinux/donate/crypto"
                   target="_blank"
                   rel="noopener noreferrer"
+                  className="flex items-center justify-center gap-2"
                 >
                   <SiBitcoin size={16} />
-                  Every.org (Crypto)
+                  <span>Every.org (Crypto)</span>
                 </Link>
               </Button>
               <Button asChild className="w-full" variant="outline">
@@ -127,9 +131,10 @@ export default function ContributePage() {
                   href="https://cash.app/$allthingslinux"
                   target="_blank"
                   rel="noopener noreferrer"
+                  className="flex items-center justify-center gap-2"
                 >
                   <SiCashapp size={16} />
-                  Cash App
+                  <span>Cash App</span>
                 </Link>
               </Button>
               <Button asChild className="w-full" variant="outline">
@@ -137,9 +142,10 @@ export default function ContributePage() {
                   href="https://donate.stripe.com/28EbJ27Dm9nAcHWdXk1wY06"
                   target="_blank"
                   rel="noopener noreferrer"
+                  className="flex items-center justify-center gap-2"
                 >
                   <SiStripe size={16} />
-                  Stripe (One-Time)
+                  <span>Stripe (One-Time)</span>
                 </Link>
               </Button>
             </div>

--- a/app/contribute/page.tsx
+++ b/app/contribute/page.tsx
@@ -173,7 +173,7 @@ export default function ContributePage() {
             </CardHeader>
             <CardContent>
               <Button asChild className="w-full" size="lg">
-                <Link href="/get-involved">Browse Open Roles</Link>
+                <Link href="/apply">Browse Open Roles</Link>
               </Button>
             </CardContent>
           </Card>

--- a/app/contribute/page.tsx
+++ b/app/contribute/page.tsx
@@ -1,0 +1,305 @@
+import Link from 'next/link';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { getPageMetadata } from '../metadata';
+import type { Metadata } from 'next';
+import {
+  Heart,
+  Code,
+  Users,
+  DollarSign,
+  Github,
+  ExternalLink,
+  MessageSquare,
+  BookOpen,
+} from 'lucide-react';
+import { FinancialSupportDialog } from '@/components/pages/contribute/financial-support-dialog';
+
+export const metadata: Metadata = getPageMetadata('contribute');
+
+export default function ContributePage() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 py-12 sm:py-16 lg:py-20 max-w-6xl">
+      {/* Hero Section */}
+      <div className="relative overflow-hidden rounded-xl border border-primary/10 mb-12 sm:mb-16">
+        <div className="absolute inset-0 bg-[radial-gradient(#333_1px,transparent_1px)] [background-size:20px_20px] opacity-20"></div>
+
+        <div className="relative py-4 sm:py-5 md:py-6 px-6 sm:px-10">
+          <div className="max-w-3xl mx-auto text-center">
+            <h1 className="text-2xl sm:text-2xl md:text-3xl font-bold mb-6">
+              Contribute to All Things Linux
+            </h1>
+
+            <p className="text-lg sm:text-xl text-muted-foreground leading-relaxed">
+              Help us build the most welcoming Linux community. Whether through
+              donations, code contributions, or volunteering your time, every
+              contribution makes a difference.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Ways to Contribute Section */}
+      <div className="mb-16 space-y-6">
+        {/* Financial Support - Full Width */}
+        <Card className="border-2 hover:shadow-lg transition-all">
+          <CardHeader>
+            <div className="flex items-center gap-3 mb-2">
+              <div className="p-2 rounded-lg bg-green-500/10">
+                <DollarSign className="h-6 w-6 text-green-600 dark:text-green-500" />
+              </div>
+              <CardTitle className="text-2xl">Financial Support</CardTitle>
+              <FinancialSupportDialog />
+            </div>
+            <CardDescription className="text-lg">
+              Your donations help us maintain infrastructure, run events, and
+              grow our community.
+              <span className="block mt-2 text-sm">
+                <i>
+                  In general Open Collective is the best platform to donate on.
+                  However for Amex, PayPal has lower fees. For Crypto, Stripe
+                  has the lowest fees but every.org provides more currency
+                  options.
+                </i>{' '}
+                <b>
+                  For larger donations or more details on how the fees work you
+                  can click the "Learn More" button above.
+                </b>
+              </span>
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <Button asChild className="w-full" size="lg">
+              <Link
+                href="https://opencollective.com/allthingslinux"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Open Collective
+                <ExternalLink className="ml-2 h-4 w-4" />
+              </Link>
+            </Button>
+            <div className="grid grid-cols-2 gap-3">
+              <Button asChild className="w-full" size="lg" variant="outline">
+                <Link
+                  href="https://donate.stripe.com/28EbJ27Dm9nAcHWdXk1wY06"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Stripe (One-Time)
+                  <ExternalLink className="ml-2 h-4 w-4" />
+                </Link>
+              </Button>
+              <Button asChild className="w-full" size="lg" variant="outline">
+                <Link
+                  href="https://donate.stripe.com/bJe8wQf5O2ZccHW06u1wY07"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Stripe (Monthly)
+                  <ExternalLink className="ml-2 h-4 w-4" />
+                </Link>
+              </Button>
+            </div>
+            <Button asChild className="w-full" size="lg" variant="outline">
+              <Link
+                href="https://paypal.com/donate/?hosted_button_id=9R5Y3RDAMF6D8"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                PayPal
+                <ExternalLink className="ml-2 h-4 w-4" />
+              </Link>
+            </Button>
+            <Button asChild className="w-full" size="lg" variant="outline">
+              <Link
+                href="https://every.org/allthingslinux/donate/crypto"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Every.org (Crypto)
+                <ExternalLink className="ml-2 h-4 w-4" />
+              </Link>
+            </Button>
+            <Button asChild className="w-full" size="lg" variant="outline">
+              <Link
+                href="https://cash.app/$allthingslinux"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Cash App
+                <ExternalLink className="ml-2 h-4 w-4" />
+              </Link>
+            </Button>
+            <Button asChild variant="secondary" className="w-full" size="lg">
+              <Link href="/open">View our Financial Records!</Link>
+            </Button>
+          </CardContent>
+        </Card>
+
+        {/* Volunteer and Wiki - Second Row */}
+        <div className="grid md:grid-cols-2 gap-6">
+          {/* Volunteer Your Time */}
+          <Card className="border-2 hover:shadow-lg transition-all">
+            <CardHeader>
+              <div className="flex items-center gap-3 mb-2">
+                <div className="p-2 rounded-lg bg-purple-500/10">
+                  <Users className="h-6 w-6 text-purple-600 dark:text-purple-500" />
+                </div>
+                <CardTitle className="text-2xl">Volunteer Your Time</CardTitle>
+              </div>
+              <CardDescription className="text-lg">
+                Join our team and help manage the community, create content, and
+                organize events.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button asChild className="w-full" size="lg">
+                <Link href="/get-involved">Browse Open Roles</Link>
+              </Button>
+            </CardContent>
+          </Card>
+
+          {/* Contribute to Wiki */}
+          <Card className="border-2 hover:shadow-lg transition-all">
+            <CardHeader>
+              <div className="flex items-center gap-3 mb-2">
+                <div className="p-2 rounded-lg bg-cyan-500/10">
+                  <BookOpen className="h-6 w-6 text-cyan-600 dark:text-cyan-500" />
+                </div>
+                <CardTitle className="text-2xl">
+                  Contribute to the Wiki
+                </CardTitle>
+              </div>
+              <CardDescription className="text-lg">
+                Share your knowledge by contributing editing or writing articles
+                and guides.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button asChild className="w-full" size="lg">
+                <Link
+                  href="https://atl.wiki"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Visit Wiki
+                  <ExternalLink className="ml-2 h-4 w-4" />
+                </Link>
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Code Contributions and Community Support - Third Row */}
+        <div className="grid md:grid-cols-2 gap-6">
+          {/* Code Contributions */}
+          <Card className="border-2 hover:shadow-lg transition-all">
+            <CardHeader>
+              <div className="flex items-center gap-3 mb-2">
+                <div className="p-2 rounded-lg bg-blue-500/10">
+                  <Code className="h-6 w-6 text-blue-600 dark:text-blue-500" />
+                </div>
+                <CardTitle className="text-2xl">Code Contributions</CardTitle>
+              </div>
+              <CardDescription className="text-lg">
+                Help us build and improve our open-source projects and
+                infrastructure.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <Button asChild className="w-full" size="lg">
+                <Link
+                  href="https://github.com/allthingslinux"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <Github className="mr-2 h-4 w-4" />
+                  View on GitHub
+                  <ExternalLink className="ml-2 h-4 w-4" />
+                </Link>
+              </Button>
+            </CardContent>
+          </Card>
+
+          {/* Community Support */}
+          <Card className="border-2 hover:shadow-lg transition-all">
+            <CardHeader>
+              <div className="flex items-center gap-3 mb-2">
+                <div className="p-2 rounded-lg bg-orange-500/10">
+                  <MessageSquare className="h-6 w-6 text-orange-600 dark:text-orange-500" />
+                </div>
+                <CardTitle className="text-2xl">Community Support</CardTitle>
+              </div>
+              <CardDescription className="text-lg">
+                Help others learn Linux, answer questions, and share your
+                knowledge.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button asChild className="w-full" size="lg">
+                <Link
+                  href="https://discord.gg/allthingslinux"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Join Our Discord
+                  <ExternalLink className="ml-2 h-4 w-4" />
+                </Link>
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      {/* Why Contribute Section */}
+      <Card className="border-2 mb-16">
+        <CardHeader>
+          <CardTitle className="text-2xl text-center">
+            Why Contribute?
+          </CardTitle>
+          <CardDescription className="text-center text-lg">
+            Your contributions help us achieve our mission
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-8">
+          <div className="grid sm:grid-cols-3 gap-6">
+            <div className="text-center space-y-2">
+              <div className="text-4xl font-bold text-primary">20k+</div>
+              <p className="text-sm text-muted-foreground">Community Members</p>
+            </div>
+            <div className="text-center space-y-2">
+              <div className="text-4xl font-bold text-primary">100%</div>
+              <p className="text-sm text-muted-foreground">Open Source</p>
+            </div>
+            <div className="text-center space-y-2">
+              <div className="text-4xl font-bold text-primary">24/7</div>
+              <p className="text-sm text-muted-foreground">Community Support</p>
+            </div>
+          </div>
+
+          {/* Transparency Section */}
+          <div className="text-center space-y-4 bg-muted/50 rounded-lg p-8">
+            <h3 className="text-xl font-semibold">
+              We Practice Radical Transparency
+            </h3>
+            <p className="text-muted-foreground max-w-2xl mx-auto">
+              As a 501(c)(3) non-profit, we're committed to complete
+              transparency. We publish all our financials in real-time and share
+              all of our decisions openly with the community.
+            </p>
+            <Button asChild variant="outline" size="lg">
+              <Link href="/open">View Our Finances</Link>
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/contribute/page.tsx
+++ b/app/contribute/page.tsx
@@ -10,7 +10,6 @@ import { Button } from '@/components/ui/button';
 import { getPageMetadata } from '../metadata';
 import type { Metadata } from 'next';
 import {
-  Heart,
   Code,
   Users,
   DollarSign,
@@ -19,6 +18,13 @@ import {
   MessageSquare,
   BookOpen,
 } from 'lucide-react';
+import {
+  SiOpencollective,
+  SiPaypal,
+  SiStripe,
+  SiBitcoin,
+  SiCashapp,
+} from 'react-icons/si';
 import { FinancialSupportDialog } from '@/components/pages/contribute/financial-support-dialog';
 
 export const metadata: Metadata = getPageMetadata('contribute');
@@ -74,71 +80,71 @@ export default function ContributePage() {
               </span>
             </CardDescription>
           </CardHeader>
-          <CardContent className="space-y-3">
-            <Button asChild className="w-full" size="lg">
-              <Link
-                href="https://opencollective.com/allthingslinux"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Open Collective
-                <ExternalLink className="ml-2 h-4 w-4" />
-              </Link>
-            </Button>
-            <div className="grid grid-cols-2 gap-3">
-              <Button asChild className="w-full" size="lg" variant="outline">
+          <CardContent>
+            <div className="grid grid-cols-3 gap-3">
+              <Button asChild className="w-full">
                 <Link
-                  href="https://donate.stripe.com/28EbJ27Dm9nAcHWdXk1wY06"
+                  href="https://opencollective.com/allthingslinux"
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  Stripe (One-Time)
-                  <ExternalLink className="ml-2 h-4 w-4" />
+                  <SiOpencollective size={16} />
+                  Open Collective
                 </Link>
               </Button>
-              <Button asChild className="w-full" size="lg" variant="outline">
+              <Button asChild className="w-full" variant="outline">
+                <Link
+                  href="https://paypal.com/donate/?hosted_button_id=9R5Y3RDAMF6D8"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <SiPaypal size={16} />
+                  PayPal
+                </Link>
+              </Button>
+              <Button asChild className="w-full" variant="outline">
                 <Link
                   href="https://donate.stripe.com/bJe8wQf5O2ZccHW06u1wY07"
                   target="_blank"
                   rel="noopener noreferrer"
                 >
+                  <SiStripe size={16} />
                   Stripe (Monthly)
-                  <ExternalLink className="ml-2 h-4 w-4" />
+                </Link>
+              </Button>
+              <Button asChild className="w-full" variant="outline">
+                <Link
+                  href="https://every.org/allthingslinux/donate/crypto"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <SiBitcoin size={16} />
+                  Every.org (Crypto)
+                </Link>
+              </Button>
+              <Button asChild className="w-full" variant="outline">
+                <Link
+                  href="https://cash.app/$allthingslinux"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <SiCashapp size={16} />
+                  Cash App
+                </Link>
+              </Button>
+              <Button asChild className="w-full" variant="outline">
+                <Link
+                  href="https://donate.stripe.com/28EbJ27Dm9nAcHWdXk1wY06"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <SiStripe size={16} />
+                  Stripe (One-Time)
                 </Link>
               </Button>
             </div>
-            <Button asChild className="w-full" size="lg" variant="outline">
-              <Link
-                href="https://paypal.com/donate/?hosted_button_id=9R5Y3RDAMF6D8"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                PayPal
-                <ExternalLink className="ml-2 h-4 w-4" />
-              </Link>
-            </Button>
-            <Button asChild className="w-full" size="lg" variant="outline">
-              <Link
-                href="https://every.org/allthingslinux/donate/crypto"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Every.org (Crypto)
-                <ExternalLink className="ml-2 h-4 w-4" />
-              </Link>
-            </Button>
-            <Button asChild className="w-full" size="lg" variant="outline">
-              <Link
-                href="https://cash.app/$allthingslinux"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Cash App
-                <ExternalLink className="ml-2 h-4 w-4" />
-              </Link>
-            </Button>
-            <Button asChild variant="secondary" className="w-full" size="lg">
-              <Link href="/open">View our Financial Records!</Link>
+            <Button asChild variant="secondary" className="w-full mt-4">
+              <Link href="/open">View our Financial Records</Link>
             </Button>
           </CardContent>
         </Card>

--- a/app/contribute/page.tsx
+++ b/app/contribute/page.tsx
@@ -14,9 +14,10 @@ import {
   Users,
   DollarSign,
   Github,
-  ExternalLink,
   MessageSquare,
   BookOpen,
+  FileText,
+  BarChart3,
 } from 'lucide-react';
 import {
   SiOpencollective,
@@ -34,7 +35,7 @@ export default function ContributePage() {
     <div className="container mx-auto px-4 sm:px-6 py-12 sm:py-16 lg:py-20 max-w-6xl">
       {/* Hero Section */}
       <div className="relative overflow-hidden rounded-xl border border-primary/10 mb-12 sm:mb-16">
-        <div className="absolute inset-0 bg-[radial-gradient(#333_1px,transparent_1px)] [background-size:20px_20px] opacity-20"></div>
+        <div className="absolute inset-0 bg-[radial-gradient(#333_1px,transparent_1px)] bg-size-[20px_20px] opacity-20"></div>
 
         <div className="relative py-4 sm:py-5 md:py-6 px-6 sm:px-10">
           <div className="max-w-3xl mx-auto text-center">
@@ -43,7 +44,7 @@ export default function ContributePage() {
             </h1>
 
             <p className="text-lg sm:text-xl text-muted-foreground leading-relaxed">
-              Help us build the most welcoming Linux community. Whether through
+              Help us build the most welcoming and passionateLinux community. Whether through
               donations, code contributions, or volunteering your time, every
               contribution makes a difference.
             </p>
@@ -60,24 +61,11 @@ export default function ContributePage() {
               <div className="p-2 rounded-lg bg-green-500/10">
                 <DollarSign className="h-6 w-6 text-green-600 dark:text-green-500" />
               </div>
-              <CardTitle className="text-2xl">Financial Support</CardTitle>
-              <FinancialSupportDialog />
+              <CardTitle className="text-2xl">Donate financially</CardTitle>
             </div>
             <CardDescription className="text-lg">
               Your donations help us maintain infrastructure, run events, and
               grow our community.
-              <span className="block mt-2 text-sm">
-                <i>
-                  In general Open Collective is the best platform to donate on.
-                  However for Amex, PayPal has lower fees. For Crypto, Stripe
-                  has the lowest fees but every.org provides more currency
-                  options.
-                </i>{' '}
-                <strong>
-                  For larger donations or more details on how the fees work you
-                  can click the "Learn More" button above.
-                </strong>  
-              </span>
             </CardDescription>
           </CardHeader>
           <CardContent>
@@ -87,10 +75,10 @@ export default function ContributePage() {
                   href="https://opencollective.com/allthingslinux"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex items-center justify-center gap-2"
+                  className="flex items-center justify-center gap-2 leading-none"
                 >
-                  <SiOpencollective size={16} />
-                  <span>Open Collective</span>
+                  <SiOpencollective className="h-4 w-4 shrink-0" />
+                  <span className="leading-none">Open Collective</span>
                 </Link>
               </Button>
               <Button asChild className="w-full" variant="outline">
@@ -98,10 +86,10 @@ export default function ContributePage() {
                   href="https://paypal.com/donate/?hosted_button_id=9R5Y3RDAMF6D8"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex items-center justify-center gap-2"
+                  className="flex items-center justify-center gap-2 leading-none"
                 >
-                  <SiPaypal size={16} />
-                  <span>PayPal</span>
+                  <SiPaypal className="h-4 w-4 shrink-0" />
+                  <span className="leading-none">PayPal</span>
                 </Link>
               </Button>
               <Button asChild className="w-full" variant="outline">
@@ -109,10 +97,10 @@ export default function ContributePage() {
                   href="https://donate.stripe.com/bJe8wQf5O2ZccHW06u1wY07"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex items-center justify-center gap-2"
+                  className="flex items-center justify-center gap-2 leading-none"
                 >
-                  <SiStripe size={16} />
-                  <span>Stripe (Monthly)</span>
+                  <SiStripe className="h-4 w-4 shrink-0" />
+                  <span className="leading-none">Stripe (Monthly)</span>
                 </Link>
               </Button>
               <Button asChild className="w-full" variant="outline">
@@ -120,10 +108,10 @@ export default function ContributePage() {
                   href="https://every.org/allthingslinux/donate/crypto"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex items-center justify-center gap-2"
+                  className="flex items-center justify-center gap-2 leading-none"
                 >
-                  <SiBitcoin size={16} />
-                  <span>Every.org (Crypto)</span>
+                  <SiBitcoin className="h-4 w-4 shrink-0" />
+                  <span className="leading-none">Every.org (Crypto)</span>
                 </Link>
               </Button>
               <Button asChild className="w-full" variant="outline">
@@ -131,10 +119,10 @@ export default function ContributePage() {
                   href="https://cash.app/$allthingslinux"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex items-center justify-center gap-2"
+                  className="flex items-center justify-center gap-2 leading-none"
                 >
-                  <SiCashapp size={16} />
-                  <span>Cash App</span>
+                  <SiCashapp className="h-4 w-4 shrink-0" />
+                  <span className="leading-none">Cash App</span>
                 </Link>
               </Button>
               <Button asChild className="w-full" variant="outline">
@@ -142,51 +130,66 @@ export default function ContributePage() {
                   href="https://donate.stripe.com/28EbJ27Dm9nAcHWdXk1wY06"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex items-center justify-center gap-2"
+                  className="flex items-center justify-center gap-2 leading-none"
                 >
-                  <SiStripe size={16} />
-                  <span>Stripe (One-Time)</span>
+                  <SiStripe className="h-4 w-4 shrink-0" />
+                  <span className="leading-none">Stripe (One-Time)</span>
                 </Link>
               </Button>
             </div>
             <Button asChild variant="secondary" className="w-full mt-4">
-              <Link href="/open">View our Financial Records</Link>
+              <Link
+                href="/open"
+                className="flex items-center justify-center gap-2"
+              >
+                <FileText className="h-4 w-4" />
+                View our Financial Records
+              </Link>
             </Button>
+            <div className="mt-3 flex justify-center">
+              <FinancialSupportDialog />
+            </div>
           </CardContent>
         </Card>
 
-        {/* Volunteer and Wiki - Second Row */}
-        <div className="grid md:grid-cols-2 gap-6">
+        {/* Volunteer, Wiki, Code, Community */}
+        <div className="grid sm:grid-cols-2 gap-6">
           {/* Volunteer Your Time */}
-          <Card className="border-2 hover:shadow-lg transition-all">
-            <CardHeader>
+          <Card className="border-2 hover:shadow-lg transition-all flex flex-col h-full">
+            <CardHeader className="flex-1">
               <div className="flex items-center gap-3 mb-2">
                 <div className="p-2 rounded-lg bg-purple-500/10">
                   <Users className="h-6 w-6 text-purple-600 dark:text-purple-500" />
                 </div>
-                <CardTitle className="text-2xl">Volunteer Your Time</CardTitle>
+                <CardTitle className="text-2xl">Volunteer your time</CardTitle>
               </div>
               <CardDescription className="text-lg">
                 Join our team and help manage the community, create content, and
                 organize events.
               </CardDescription>
             </CardHeader>
-            <CardContent>
-              <Button asChild className="w-full" size="lg">
-                <Link href="/apply">Browse Open Roles</Link>
+            <CardContent className="mt-auto">
+              <Button asChild className="w-full" size="lg" variant="default">
+                <Link
+                  href="/apply"
+                  className="flex items-center justify-center gap-2"
+                >
+                  <Users className="h-4 w-4" />
+                  Browse Open Roles
+                </Link>
               </Button>
             </CardContent>
           </Card>
 
           {/* Contribute to Wiki */}
-          <Card className="border-2 hover:shadow-lg transition-all">
-            <CardHeader>
+          <Card className="border-2 hover:shadow-lg transition-all flex flex-col h-full">
+            <CardHeader className="flex-1">
               <div className="flex items-center gap-3 mb-2">
                 <div className="p-2 rounded-lg bg-cyan-500/10">
                   <BookOpen className="h-6 w-6 text-cyan-600 dark:text-cyan-500" />
                 </div>
                 <CardTitle className="text-2xl">
-                  Contribute to the Wiki
+                  Contribute your knowledge
                 </CardTitle>
               </div>
               <CardDescription className="text-lg">
@@ -194,75 +197,74 @@ export default function ContributePage() {
                 and guides.
               </CardDescription>
             </CardHeader>
-            <CardContent>
-              <Button asChild className="w-full" size="lg">
+            <CardContent className="mt-auto">
+              <Button asChild className="w-full" size="lg" variant="default">
                 <Link
                   href="https://atl.wiki"
                   target="_blank"
                   rel="noopener noreferrer"
+                  className="flex items-center justify-center gap-2"
                 >
+                  <BookOpen className="h-4 w-4" />
                   Visit Wiki
-                  <ExternalLink className="ml-2 h-4 w-4" />
                 </Link>
               </Button>
             </CardContent>
           </Card>
-        </div>
 
-        {/* Code Contributions and Community Support - Third Row */}
-        <div className="grid md:grid-cols-2 gap-6">
           {/* Code Contributions */}
-          <Card className="border-2 hover:shadow-lg transition-all">
-            <CardHeader>
+          <Card className="border-2 hover:shadow-lg transition-all flex flex-col h-full">
+            <CardHeader className="flex-1">
               <div className="flex items-center gap-3 mb-2">
                 <div className="p-2 rounded-lg bg-blue-500/10">
                   <Code className="h-6 w-6 text-blue-600 dark:text-blue-500" />
                 </div>
-                <CardTitle className="text-2xl">Code Contributions</CardTitle>
+                <CardTitle className="text-2xl">Contribute your code</CardTitle>
               </div>
               <CardDescription className="text-lg">
                 Help us build and improve our open-source projects and
                 infrastructure.
               </CardDescription>
             </CardHeader>
-            <CardContent className="space-y-3">
-              <Button asChild className="w-full" size="lg">
+            <CardContent className="space-y-3 mt-auto">
+              <Button asChild className="w-full" size="lg" variant="default">
                 <Link
                   href="https://github.com/allthingslinux"
                   target="_blank"
                   rel="noopener noreferrer"
+                  className="flex items-center justify-center gap-2"
                 >
-                  <Github className="mr-2 h-4 w-4" />
+                  <Github className="h-4 w-4" />
                   View on GitHub
-                  <ExternalLink className="ml-2 h-4 w-4" />
                 </Link>
               </Button>
             </CardContent>
           </Card>
 
           {/* Community Support */}
-          <Card className="border-2 hover:shadow-lg transition-all">
-            <CardHeader>
+          <Card className="border-2 hover:shadow-lg transition-all flex flex-col h-full">
+            <CardHeader className="flex-1">
               <div className="flex items-center gap-3 mb-2">
                 <div className="p-2 rounded-lg bg-orange-500/10">
                   <MessageSquare className="h-6 w-6 text-orange-600 dark:text-orange-500" />
                 </div>
-                <CardTitle className="text-2xl">Community Support</CardTitle>
+                <CardTitle className="text-2xl">Help and support</CardTitle>
               </div>
               <CardDescription className="text-lg">
                 Help others learn Linux, answer questions, and share your
                 knowledge.
               </CardDescription>
             </CardHeader>
-            <CardContent>
-              <Button asChild className="w-full" size="lg">
+            <CardContent className="mt-auto">
+              <Button asChild className="w-full" size="lg" variant="default">
                 <Link
-                  href="https://discord.gg/allthingslinux"
+                  href="https://discord.gg/linux"
                   target="_blank"
                   rel="noopener noreferrer"
+                  className="flex items-center justify-center gap-2"
                 >
+                  <MessageSquare className="h-4 w-4" />
                   Join Our Discord
-                  <ExternalLink className="ml-2 h-4 w-4" />
                 </Link>
               </Button>
             </CardContent>
@@ -277,18 +279,18 @@ export default function ContributePage() {
             Why Contribute?
           </CardTitle>
           <CardDescription className="text-center text-lg">
-            Your contributions help us achieve our mission
+            Your contributions help us achieve our mission and vision.
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-8">
           <div className="grid sm:grid-cols-3 gap-6">
             <div className="text-center space-y-2">
-              <div className="text-4xl font-bold text-primary">20k+</div>
-              <p className="text-sm text-muted-foreground">Community Members</p>
+              <div className="text-4xl font-bold text-primary">20+</div>
+              <p className="text-sm text-muted-foreground">Dedicated Volunteers</p>
             </div>
             <div className="text-center space-y-2">
               <div className="text-4xl font-bold text-primary">100%</div>
-              <p className="text-sm text-muted-foreground">Open Source</p>
+              <p className="text-sm text-muted-foreground">Open Source and Non-Profit</p>
             </div>
             <div className="text-center space-y-2">
               <div className="text-4xl font-bold text-primary">24/7</div>
@@ -306,8 +308,11 @@ export default function ContributePage() {
               transparency. We publish all our financials in real-time and share
               all of our decisions openly with the community.
             </p>
-            <Button asChild variant="outline" size="lg">
-              <Link href="/open">View Our Finances</Link>
+          <Button asChild variant="outline" size="lg">
+            <Link href="/open" className="flex items-center justify-center gap-2">
+              <BarChart3 className="h-4 w-4" />
+              View Our Finances
+            </Link>
             </Button>
           </div>
         </CardContent>

--- a/app/contribute/page.tsx
+++ b/app/contribute/page.tsx
@@ -44,7 +44,7 @@ export default function ContributePage() {
             </h1>
 
             <p className="text-lg sm:text-xl text-muted-foreground leading-relaxed">
-              Help us build the most welcoming and passionateLinux community. Whether through
+              Help us build the most welcoming and passionate Linux community. Whether through
               donations, code contributions, or volunteering your time, every
               contribution makes a difference.
             </p>

--- a/app/metadata.ts
+++ b/app/metadata.ts
@@ -189,6 +189,11 @@ export const getPageMetadata = (page: string): Metadata => {
       description:
         'Learn how to get involved with All Things Linux and contribute to our projects.',
     },
+    contribute: {
+      title: 'Contribute',
+      description:
+        'Support All Things Linux through donations, code contributions, volunteering, or community support.',
+    },
     open: {
       title: 'Open',
       description: 'View our public financial reports and insights.',

--- a/app/metadata.ts
+++ b/app/metadata.ts
@@ -184,10 +184,10 @@ export const getPageMetadata = (page: string): Metadata => {
       description:
         'Stay updated with the latest news, tutorials, and insights about Linux and open source software.',
     },
-    'get-involved': {
-      title: 'Get Involved',
+    apply: {
+      title: 'Apply',
       description:
-        'Learn how to get involved with All Things Linux and contribute to our projects.',
+        'Apply to join All Things Linux and contribute to our community projects.',
     },
     contribute: {
       title: 'Contribute',

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -10,7 +10,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     '/about',
     '/code-of-conduct',
     '/blog',
-    '/get-involved',
+    '/apply',
     // Add all other static routes here
   ].map((route) => ({
     url: `${baseUrl}${route}`,

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -11,6 +11,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     '/code-of-conduct',
     '/blog',
     '/apply',
+    '/contribute',
     // Add all other static routes here
   ].map((route) => ({
     url: `${baseUrl}${route}`,

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -7,7 +7,6 @@ import {
   FaRss,
 } from 'react-icons/fa';
 import { BsOpencollective } from 'react-icons/bs';
-import { IoIosArrowUp } from 'react-icons/io';
 
 import { Separator } from '@/components/ui/separator';
 import { Privacy, Cookies, Terms, Security } from '@/components/consent';
@@ -21,12 +20,13 @@ const sections = [
       { name: 'Code of Conduct', href: '/code-of-conduct' },
       { name: 'Blog', href: '/blog' },
       { name: 'Apply', href: '/apply' },
+      { name: 'Contribute', href: '/contribute' },
     ],
   },
   {
     title: 'Projects',
     links: [
-      { name: 'tux', href: 'https://tux.atl.tools' },
+      { name: 'tux', href: 'https://github.com/allthingslinux/tux' },
       { name: 'atl.wiki', href: 'https://atl.wiki' },
       { name: 'atl.tools', href: 'https://atl.tools' },
       { name: 'atl.chat', href: 'https://atl.chat' },
@@ -115,8 +115,8 @@ const FooterSection = ({
   <div>
     <h3 className="mb-4 font-bold">{title}</h3>
     <ul className="space-y-4 text-muted-foreground">
-      {links.map((link, linkIdx) => (
-        <FooterLink key={linkIdx} name={link.name} href={link.href} />
+      {links.map((link) => (
+        <FooterLink key={link.name} name={link.name} href={link.href} />
       ))}
     </ul>
   </div>
@@ -144,9 +144,9 @@ const SocialSection = () => (
   <div>
     <h3 className="mb-4 font-bold md:block hidden">Social</h3>
     <ul className="flex items-center justify-center md:justify-start space-x-6 text-muted-foreground">
-      {socialLinks.map((social, idx) => (
+      {socialLinks.map((social) => (
         <SocialIcon
-          key={idx}
+          key={social.label}
           Icon={social.icon}
           href={social.href}
           label={social.label}
@@ -162,15 +162,23 @@ const SocialSection = () => (
         admin@allthingslinux.org
       </a>
     </div>
+    <div className="mt-5 text-center md:text-left">
+      <a
+        href="/open"
+        className="text-xl font-bold text-muted-foreground hover:text-primary transition-colors"
+      >
+        /open
+      </a>
+    </div>
   </div>
 );
 
 // Main sections grid
 const FooterSections = () => (
   <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-4">
-    {sections.map((section, sectionIdx) => (
+    {sections.map((section) => (
       <FooterSection
-        key={sectionIdx}
+        key={section.title}
         title={section.title}
         links={section.links}
       />
@@ -206,8 +214,7 @@ const MobileFooter = () => (
 const DesktopCopyright = () => (
   <div className="hidden md:flex justify-between items-center">
     <p className="text-sm text-muted-foreground">
-      © {new Date().getFullYear()} All Things Linux • Made with ❤️ • All Rights
-      Reserved
+      All Things Linux • Made with ☕ & 💛
     </p>
     <a
       href="https://github.com/allthingslinux/allthingslinux"

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -20,7 +20,7 @@ const sections = [
       { name: 'About', href: '/about' },
       { name: 'Code of Conduct', href: '/code-of-conduct' },
       { name: 'Blog', href: '/blog' },
-      { name: 'Get Involved', href: '/get-involved' },
+      { name: 'Apply', href: '/apply' },
     ],
   },
   {

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -23,7 +23,7 @@ const navItems = [
   { name: 'Wiki', href: 'https://atl.wiki' },
   { name: 'Tools', href: 'https://atl.tools' },
   { name: 'Open', href: '/open' },
-  { name: 'Get Involved', href: '/get-involved' },
+  { name: 'Apply', href: '/apply' },
 ];
 
 // Logo component

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -24,6 +24,7 @@ const navItems = [
   { name: 'Tools', href: 'https://atl.tools' },
   { name: 'Open', href: '/open' },
   { name: 'Apply', href: '/apply' },
+  { name: 'Contribute', href: '/contribute' },
 ];
 
 // Logo component

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -23,6 +23,7 @@ const navItems = [
   { name: 'Wiki', href: 'https://atl.wiki' },
   { name: 'Tools', href: 'https://atl.tools' },
   { name: 'Open', href: '/open' },
+  { name: 'Get Involved', href: '/get-involved' },
 ];
 
 // Logo component
@@ -77,7 +78,7 @@ const DesktopNavigation = () => (
 
 // CTA button component
 const CTAButton = ({ className }: { className?: string }) => (
-  <Link href="/get-involved">
+  <Link href="/contribute">
     <Button
       variant="default"
       size="default"
@@ -87,7 +88,7 @@ const CTAButton = ({ className }: { className?: string }) => (
         className
       )}
     >
-      Get Involved
+      Contribute & Donate
     </Button>
   </Link>
 );
@@ -146,9 +147,7 @@ const MobileNavigation = () => {
       <SheetContent side="right" className="w-[280px]">
         <SheetHeader className="mb-8 pb-4 border-b">
           <SheetTitle className="text-left">
-            <span className="font-bold text-foreground">
-              All Things Linux
-            </span>
+            <span className="font-bold text-foreground">All Things Linux</span>
           </SheetTitle>
         </SheetHeader>
         <div className="flex flex-col gap-8">

--- a/components/pages/about/values.tsx
+++ b/components/pages/about/values.tsx
@@ -19,7 +19,7 @@ const valuesList = [
     id: 1,
     title: 'Community',
     description:
-      'We connect over 14,000 Linux enthusiasts through collaboration and knowledge sharing. Our regular events allow members to demonstrate their skills, with prizes enhancing a spirit of friendly competition.',
+      'We connect over 20,000 Linux enthusiasts through collaboration and knowledge sharing. Our regular events allow members to demonstrate their skills, with prizes enhancing a spirit of friendly competition.',
     icon: Users,
   },
   {

--- a/components/pages/contribute/financial-support-dialog.tsx
+++ b/components/pages/contribute/financial-support-dialog.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Info } from 'lucide-react';
+
+export function FinancialSupportDialog() {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="ghost" size="sm" className="ml-auto">
+          <Info className="h-4 w-4 mr-1" />
+          Learn More
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>About Financial Support</DialogTitle>
+          <DialogDescription>
+            Your donations directly support our mission to build and maintain
+            the most welcoming Linux community. All donations are tax-deductible
+            as we are a registered 501(c)(3) non-profit organization.
+            <br /> <br />
+            Below is a breakdown of the fees that we are charged on your
+            donations. These are included in the total amount you donate, so you
+            don't have to worry about any additional fees.
+            <br /> <br />
+            In general Open Collective is the best platform to donate on, it has
+            the most donation options and charges the lowest fees (via Stripe
+            with no platform fee), however for Amex cards PayPal has lower fees.
+            For Crypto donations, Stripe has the lowest fees but every.org
+            provides more currency options.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4 pt-2">
+          <div className="space-y-2">
+            <h4 className="font-semibold text-foreground">Payment Methods:</h4>
+            <ul className="list-disc list-inside space-y-1 text-sm">
+              <li>
+                <strong>Stripe:</strong> 2.2% + $0.30, +1% for non-US, +1.3% for
+                Amex
+              </li>
+              <li>
+                <strong>Open Collective:</strong> Stripe Fees
+              </li>
+              <li>
+                <strong>PayPal:</strong> 2.2% + $0.30, +1.5% for non-US
+              </li>
+
+              <li>
+                <strong>Every.org:</strong> Stripe Fees + 1% platform fee
+              </li>
+              <li>
+                <strong>Cash App:</strong> 2.6% + $0.15, US Only
+              </li>
+            </ul>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            For large donations or questions, please contact us via{' '}
+            <a href="mailto:admin@allthingslinux.org">
+              admin@allthingslinux.org
+            </a>{' '}
+            to ensure as much as your donation as possible goes directly to
+            supporting our community. We will work with you to find the best way
+            to donate with the lowest fees possible.
+          </p>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/pages/home/donate-cta.tsx
+++ b/components/pages/home/donate-cta.tsx
@@ -1,6 +1,5 @@
 import { memo } from 'react';
 import { Button } from '@/components/ui/button';
-import { LinkIcon } from 'lucide-react';
 import Link from 'next/link';
 
 import { BsOpencollective } from 'react-icons/bs';
@@ -27,9 +26,8 @@ const DonateCta = memo(() => {
               lights on and provide more services to the community.
             </p>
             <div className="mt-8">
-              <Link href="https://opencollective.com/allthingslinux">
-                <Button variant="secondary" size="lg" className="flex items-center gap-2">
-                  <LinkIcon />
+              <Link href="/contribute">
+                <Button variant="secondary" size="lg">
                   Donate Now
                 </Button>
               </Link>

--- a/components/pages/home/stats.tsx
+++ b/components/pages/home/stats.tsx
@@ -6,8 +6,8 @@ import { Card } from '@/components/ui/card';
 // Stats data with minimal information
 const statsData = [
   { id: 1, value: '10M+', description: 'messages' },
-  { id: 2, value: '18K+', description: 'members' },
-  { id: 3, value: '68K+', description: 'voice hours' },
+  { id: 2, value: '20K+', description: 'members' },
+  { id: 3, value: '70K+', description: 'voice hours' },
   { id: 4, value: '40+', description: 'volunteers and staff' },
   { id: 5, value: '2K+', description: 'solved support posts' },
   { id: 6, value: '10+', description: 'projects in development' },

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      'fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      'flex flex-col space-y-1.5 text-center sm:text-left',
+      className
+    )}
+    {...props}
+  />
+);
+DialogHeader.displayName = 'DialogHeader';
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+      className
+    )}
+    {...props}
+  />
+);
+DialogFooter.displayName = 'DialogFooter';
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      'text-lg font-semibold leading-none tracking-tight',
+      className
+    )}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-muted-foreground', className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+};

--- a/content/blog/news/03-2025-roundup.mdx
+++ b/content/blog/news/03-2025-roundup.mdx
@@ -42,7 +42,7 @@ We hope this brings more attention to the quality work being done by the communi
 Our main site at [allthingslinux.org](https://allthingslinux.org/) got a facelift:
 
 - New branding and structure
-- New forms for staff applications: [Get Involved](https://allthingslinux.org/get-involved)
+- New forms for staff applications: [Apply](https://allthingslinux.org/apply)
 - Google Forms are deprecated going forward
 
 ## Infrastructure

--- a/next.config.ts
+++ b/next.config.ts
@@ -101,6 +101,13 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
+        source: '/:path*',
+        headers: [
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'Content-Security-Policy', value: "frame-ancestors 'none'" },
+        ],
+      },
+      {
         source: '/api/:path*',
         headers: [
           { key: 'Access-Control-Allow-Credentials', value: 'true' },
@@ -126,6 +133,16 @@ const nextConfig: NextConfig = {
       },
       {
         source: '/get-involved',
+        destination: '/apply',
+        permanent: true,
+      },
+      {
+        source: '/roles',
+        destination: '/apply',
+        permanent: true,
+      },
+      {
+        source: '/careers',
         destination: '/apply',
         permanent: true,
       },

--- a/next.config.ts
+++ b/next.config.ts
@@ -68,7 +68,7 @@ const nextConfig: NextConfig = {
     if (process.env.NODE_ENV === 'development') {
       config.optimization.minimize = false;
     }
-    
+
     // Ignore .map files to prevent esbuild errors in OpenNext/Cloudflare builds
     // This prevents webpack from trying to process source map files
     if (isServer) {
@@ -80,12 +80,12 @@ const nextConfig: NextConfig = {
           emit: false, // Don't emit .map files
         },
       });
-      
+
       // Ignore .map files in module resolution
       config.resolve.extensions = config.resolve.extensions.filter(
         (ext: string) => ext !== '.map'
       );
-      
+
       // Add ignore plugin to completely skip .map files
       const { IgnorePlugin } = require('webpack');
       config.plugins.push(
@@ -94,7 +94,7 @@ const nextConfig: NextConfig = {
         })
       );
     }
-    
+
     return config;
   },
   // Add headers for API endpoints
@@ -112,6 +112,17 @@ const nextConfig: NextConfig = {
               'X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version',
           },
         ],
+      },
+    ];
+  },
+
+  // Add redirects
+  async redirects() {
+    return [
+      {
+        source: '/donate',
+        destination: '/contribute',
+        permanent: true,
       },
     ];
   },

--- a/next.config.ts
+++ b/next.config.ts
@@ -124,6 +124,11 @@ const nextConfig: NextConfig = {
         destination: '/contribute',
         permanent: true,
       },
+      {
+        source: '/get-involved',
+        destination: '/apply',
+        permanent: true,
+      },
     ];
   },
 

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -2,6 +2,6 @@ Contact: https://allthingslinux.org/security
 Expires: 2030-01-01T12:00:00Z
 Encryption: https://allthingslinux.org/security@allthingslinux.org-pubkey.asc
 Acknowledgements: https://allthingslinux.org/security
-Hiring: https://allthingslinux.org/get-involved
+Hiring: https://allthingslinux.org/apply
 Policy: https://allthingslinux.org/security
 Preferred-Languages: en

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -33,9 +33,9 @@
       "description": "View our community guidelines"
     },
     {
-      "name": "Get Involved",
-      "url": "/get-involved",
-      "description": "Learn how to get involved with All Things Linux"
+      "name": "Apply",
+      "url": "/apply",
+      "description": "Apply to join All Things Linux"
     }
   ],
   "screenshots": [


### PR DESCRIPTION
## Summary by Sourcery

Add a new Contribute page centralizing donation and contribution options and wire it into site navigation and routing.

New Features:
- Introduce a dedicated Contribute page outlining financial support, volunteering, wiki contributions, code contributions, and community support options.
- Add a reusable dialog component and a financial support info dialog explaining donation methods and fees.

Enhancements:
- Update header navigation and primary call-to-action labels/targets to drive users to the new Contribute experience.
- Change the home donate CTA to route through the new Contribute page instead of directly to Open Collective.
- Extend metadata configuration with SEO metadata for the Contribute page.
- Add a redirect from /donate to /contribute for backward compatibility.